### PR TITLE
feat: Dockerized CRDB, API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .idea
+.vscode
 data
 target
 
 *.bbrz
 *.xml
+
+config.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:buster AS build
+
+WORKDIR /build
+
+COPY . /build
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o target/gobblerd ./cmd/daemon/...
+
+FROM busybox:latest
+
+COPY --from=build /build/target/gobblerd /usr/bin/gobblerd
+COPY config.local.yml /etc/gobblerd/config.yml
+
+CMD /usr/bin/gobblerd

--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+## GobblerD - Blood Bowl 2 replay parser
+
+*All commands - unless specified otherwise - should be ran from the project root*
+
+### Initializing the local CockroachDB cluster
+
+**This only needs to be done if the cluster hasn't been initialized yet or the volumes have been recreated**
+
+Start the Cockroach nodes:
+
+```
+$ docker compose up roach1 roach2 roach3
+```
+
+Once the nodes are running they'll warn about being unable to communicate with other nodes in the cluster.
+To fix this, we'll have to initialize the cluster on the first node. In a new tab/window run the following:
+
+```
+$ docker compose exec roach1 ./cockroach init --insecure
+```
+
+Once this finishes, the nodes should find each other and they each report their own info in the original docker compose output.
+
+Now the nodes can communicate with each other we should create the schema:
+
+First we connect to the server running on the roach1 node
+
+```
+$ docker compose exec roach1 ./cockroach sql --insecure
+```
+
+Then we create the database and the single table we'll have for now:
+
+```
+> CREATE DATABASE gobb_dev;
+> USE gobb_dev;
+> CREATE TABLE replays (
+      id uuid NOT NULL,
+      home_team jsonb NOT NULL,
+      away_team jsonb NOT NULL
+  );
+```
+
+When this is done, quit the cockroach client (Ctrl+D) and shut the cluster down by pressing Ctrl+C in the docker compose tab/window
+
+### Starting the daemon
+
+Provided the initialization worked, this is quite simple:
+
+Build the image:
+
+```
+$ docker build -t gobblerd:latest .
+```
+
+Make sure the `image` field of the `gobblerd` service in `docker-compose.yml` is `gobblerd:latest` (or whatever tag you built the image with) and then just bring the cluster up:
+(If you're feeling confident/adventurous you can use the `-d` switch to daemonize the docker compose cluster as the logging is a bit enthusiastic right now)
+
+```
+$ docker compose up
+```
+
+### Useful stuff for debugging
+
+The CockroachDB dashboard can be accessed at http://localhost:8080
+The CockroachDB can be connected directly via the included client: `docker compose exec roach1 ./cockroach sql --insecure`
+The Gobbler server is exposed on port 80 (http://localhost/upload, http://localhost/api/replays, http://localhost/api/replays/{id})
+
+### Uploading replays
+
+There's currently no UI so the most convenient way to upload replays is using [Postman](http://postman.com)
+
+* Set the request method to POST and the URL to http://localhost/upload
+* Go to the `Body` tab and select `form-data`
+* Set the `Key` for the first row to `replay`
+* There's a dropdown when hovering over a field in the `Key` column, set it to `File` and 
+* Once set to `File` you can browse for the file you want to upload in the `Value` column

--- a/api/replay.go
+++ b/api/replay.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/alfreddobradi/go-bb-man/database"
+	"github.com/alfreddobradi/go-bb-man/helper"
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+func ReplayListHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		rows, err := db.GetReplayList()
+		if err != nil {
+			log.Printf("Failed to get replay list: %v", err)
+			helper.E(w, http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		encoder := json.NewEncoder(w)
+		if err := encoder.Encode(rows); err != nil {
+			log.Printf("Failed to encode response: %v", err)
+			helper.E(w, http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+func ReplayHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+
+		id, err := uuid.Parse(vars["id"])
+		if err != nil {
+			log.Printf("Failed to parse ID %s: %v", vars["id"], err)
+			helper.E(w, http.StatusInternalServerError)
+			return
+		}
+
+		replay, err := db.GetReplay(id)
+		if err != nil {
+			log.Printf("Failed to get replay list: %v", err)
+			helper.E(w, http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		encoder := json.NewEncoder(w)
+		if err := encoder.Encode(replay); err != nil {
+			log.Printf("Failed to encode response: %v", err)
+			helper.E(w, http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -2,23 +2,57 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
 	"sync"
+	"time"
 
+	"github.com/alfreddobradi/go-bb-man/api"
+	"github.com/alfreddobradi/go-bb-man/config"
 	"github.com/alfreddobradi/go-bb-man/database/cockroach"
+	"github.com/alfreddobradi/go-bb-man/helper"
 	"github.com/alfreddobradi/go-bb-man/processor"
 
 	"github.com/gorilla/mux"
 )
 
-func main() {
-	r := mux.NewRouter()
+var (
+	configPath string = "/etc/gobblerd/config.yml"
+)
 
-	connUrl := os.Getenv("DATABASE_URL")
-	db, err := cockroach.New(connUrl)
+func main() {
+	flag.StringVar(&configPath, "cfg", "/etc/gobblerd/config.yml", "Path to the config file")
+	flag.Parse()
+
+	if err := config.Load(configPath); err != nil {
+		panic(err)
+	}
+
+	retries := 8
+	retryInterval := 100
+
+	var db *cockroach.DB
+	var err error
+
+	try := 1
+	for {
+		db, err = cockroach.New()
+		if err != nil && try == retries {
+			break
+		}
+		if err == nil {
+			break
+		}
+		try++
+		wait := time.Duration(retryInterval) * time.Millisecond
+		log.Printf("Connection failed, retrying in %s - Error: %v", wait.String(), err)
+		time.Sleep(wait)
+		retryInterval = retryInterval << 2
+	}
+
 	if err != nil {
 		panic(err)
 	}
@@ -28,7 +62,16 @@ func main() {
 	wg.Add(1)
 	reg := processor.NewRegistry(db, wg)
 
+	r := mux.NewRouter()
+
 	r.HandleFunc("/upload", reg.HandleProcessRequest).Methods(http.MethodPost)
+	r.HandleFunc("/upload", helper.CorsHandler).Methods(http.MethodOptions)
+
+	r.HandleFunc("/api/replays", api.ReplayListHandler(db)).Methods(http.MethodGet)
+	r.HandleFunc("/api/replays", helper.CorsHandler).Methods(http.MethodOptions)
+
+	r.HandleFunc("/api/replays/{id}", api.ReplayHandler(db)).Methods(http.MethodGet)
+	r.HandleFunc("/api/replays/{id}", helper.CorsHandler).Methods(http.MethodOptions)
 
 	s := http.Server{
 		Addr:    "0.0.0.0:8080",

--- a/config.local.yml
+++ b/config.local.yml
@@ -1,0 +1,8 @@
+# This is a local config and it's overwritten by the docker-compose environment vars
+# but since the application won't start without a config we'll just leave this here
+database:
+  kind: "crdb"
+  crdb:
+    host: roach1
+    port: 26257
+    username: root

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alfreddobradi/go-bb-man/database/cockroach"
+	"github.com/alfreddobradi/goconf"
+)
+
+var Cfg *goconf.Configuration
+
+func Load(path string) error {
+	grammar := struct {
+		Database struct {
+			Kind string `env:"GOBBLER_DB_KIND"`
+			CRDB struct {
+				// postgresql://gobb:TTjYniGOFXQK6CrK2emurA@free-tier5.gcp-europe-west1.cockroachlabs.cloud:26257/gobb-dev?application_name=ccloud&options=--cluster%3Dpurple-moose-1962&sslmode=verify-full&sslrootcert=%2FUsers%2Falfred.dobradi%2F.postgresql%2Froot.crt
+				Username    string `env:"GOBBLER_DB_USERNAME"`
+				Password    string `env:"GOBBLER_DB_PASSWORD"`
+				Host        string `env:"GOBBLER_DB_HOST"`
+				Port        int    `env:"GOBBLER_DB_PORT"`
+				Database    string `env:"GOBBLER_DB_DATABASE"`
+				Options     string `env:"GOBBLER_DB_OPTIONS"`
+				SSLMode     string `yaml:"ssl_mode" env:"GOBBLER_DB_SSL_MODE"`
+				SSLRootCert string `yaml:"ssl_root_cert" env:"GOBBLER_DB_SSL_ROOT_CERT"`
+			} `yaml:"crdb"`
+		}
+	}{}
+
+	fp, err := os.OpenFile(path, os.O_RDONLY, 0755)
+	if err != nil {
+		return fmt.Errorf("Failed to open config file %s: %w", path, err)
+	}
+	defer fp.Close()
+
+	config, err := goconf.Load(&grammar, fp)
+	if err != nil {
+		return fmt.Errorf("Failed to load configuration: %w", err)
+	}
+
+	Cfg = config
+
+	if config.GetString("database.kind") == "crdb" {
+		SetCockroachConfig(config)
+	}
+
+	return nil
+}
+
+func SetCockroachConfig(config *goconf.Configuration) {
+	if host := config.GetString("database.crdb.host"); host != "" && host != cockroach.Host() {
+		cockroach.SetHost(host)
+	}
+
+	if port := config.GetInt("database.crdb.port"); port != 0 && port != cockroach.Port() {
+		cockroach.SetPort(port)
+	}
+
+	if username := config.GetString("database.crdb.username"); username != "" && username != cockroach.Username() {
+		cockroach.SetUsername(username)
+	}
+
+	if password := config.GetString("database.crdb.password"); password != "" && password != cockroach.Password() {
+		cockroach.SetPassword(password)
+	}
+
+	if database := config.GetString("database.crdb.database"); database != "" && database != cockroach.Database() {
+		cockroach.SetDatabase(database)
+	}
+
+	if options := config.GetString("database.crdb.options"); options != "" && options != cockroach.Options() {
+		cockroach.SetOptions(options)
+	}
+
+	if sslMode := config.GetString("database.crdb.ssl_mode"); sslMode != "" && sslMode != cockroach.SSLMode() {
+		cockroach.SetSSLMode(sslMode)
+	}
+
+	if sslRootCert := config.GetString("database.crdb.ssl_root_cert"); sslRootCert != "" && sslRootCert != cockroach.SSLRootCert() {
+		cockroach.SetSSLRootCert(sslRootCert)
+	}
+}

--- a/database/cockroach/cockroach.go
+++ b/database/cockroach/cockroach.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
+	"strings"
 
 	"github.com/alfreddobradi/go-bb-man/parser"
+	"github.com/google/uuid"
 
 	"github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgx"
 	pgx "github.com/jackc/pgx/v4"
@@ -15,8 +18,11 @@ type DB struct {
 	*pgx.Conn
 }
 
-func New(conn_url string) (*DB, error) {
-	config, err := pgx.ParseConfig(conn_url)
+func New() (*DB, error) {
+	log.Printf("Connecting to CockroachDB at %s", Host())
+	connUrl := createConnUrl()
+
+	config, err := pgx.ParseConfig(connUrl)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing connection url: %v", err)
 	}
@@ -52,4 +58,108 @@ func (db *DB) SaveReplay(record parser.Record) error {
 	}
 
 	return nil
+}
+
+func (db *DB) GetReplayList() ([]parser.Record, error) {
+	rows, err := db.Query(context.Background(), "SELECT * FROM replays")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to retrieve rows: %w", err)
+	}
+	response := make([]parser.Record, 0)
+	defer rows.Close()
+	for rows.Next() {
+		var id uuid.UUID
+		var home string
+		var away string
+		if err := rows.Scan(&id, &home, &away); err != nil {
+			return nil, fmt.Errorf("Failed to scan row into struct: %w", err)
+		}
+
+		var homeStruct parser.TeamStats
+		var awayStruct parser.TeamStats
+
+		if err := json.Unmarshal([]byte(home), &homeStruct); err != nil {
+			return nil, fmt.Errorf("Failed to unmarshal home team data in replay %s: %w", id.String(), err)
+		}
+
+		if err := json.Unmarshal([]byte(away), &awayStruct); err != nil {
+			return nil, fmt.Errorf("Failed to unmarshal away team data in replay %s: %w", id.String(), err)
+		}
+
+		response = append(response, parser.Record{
+			ID:   id,
+			Home: homeStruct,
+			Away: awayStruct,
+		})
+	}
+
+	return response, nil
+}
+
+func (db *DB) GetReplay(id uuid.UUID) (parser.Record, error) {
+	rows, err := db.Query(context.Background(), "SELECT * FROM replays WHERE id = $1", id)
+	if err != nil {
+		return parser.Record{}, fmt.Errorf("Failed to retrieve rows: %w", err)
+	}
+	response := make([]parser.Record, 0)
+	defer rows.Close()
+	for rows.Next() {
+		var id uuid.UUID
+		var home string
+		var away string
+		if err := rows.Scan(&id, &home, &away); err != nil {
+			return parser.Record{}, fmt.Errorf("Failed to scan row into struct: %w", err)
+		}
+
+		var homeStruct parser.TeamStats
+		var awayStruct parser.TeamStats
+
+		if err := json.Unmarshal([]byte(home), &homeStruct); err != nil {
+			return parser.Record{}, fmt.Errorf("Failed to unmarshal home team data in replay %s: %w", id.String(), err)
+		}
+
+		if err := json.Unmarshal([]byte(away), &awayStruct); err != nil {
+			return parser.Record{}, fmt.Errorf("Failed to unmarshal away team data in replay %s: %w", id.String(), err)
+		}
+
+		response = append(response, parser.Record{
+			ID:   id,
+			Home: homeStruct,
+			Away: awayStruct,
+		})
+	}
+
+	return response[0], nil
+}
+
+func createConnUrl() string {
+	auth := ""
+	if Username() != "" {
+		auth = fmt.Sprint(Username())
+		if Password() != "" {
+			auth = fmt.Sprintf("%s:%s", auth, Password())
+		}
+		auth = fmt.Sprintf("%s@", auth)
+	}
+
+	url := fmt.Sprintf("postgres://%s%s:%d/%s", auth, Host(), Port(), Database())
+
+	params := make([]string, 0)
+	if Options() != "" {
+		params = append(params, fmt.Sprintf("options=%s", Options()))
+	}
+
+	if SSLMode() != "" {
+		params = append(params, fmt.Sprintf("sslmode=%s", SSLMode()))
+	}
+
+	if SSLRootCert() != "" {
+		params = append(params, fmt.Sprintf("sslrootcert=%s", SSLRootCert()))
+	}
+
+	if len(params) > 0 {
+		url = fmt.Sprintf("%s?%s", url, strings.Join(params, "&"))
+	}
+
+	return url
 }

--- a/database/cockroach/config.go
+++ b/database/cockroach/config.go
@@ -1,0 +1,30 @@
+package cockroach
+
+var (
+	host        string = "localhost"
+	port        int    = 26257
+	username    string = ""
+	password    string = ""
+	database    string = "defaultdb"
+	sslMode     string = "disable"
+	options     string
+	sslRootCert string
+)
+
+func Host() string        { return host }
+func Port() int           { return port }
+func Username() string    { return username }
+func Password() string    { return password }
+func Database() string    { return database }
+func Options() string     { return options }
+func SSLMode() string     { return sslMode }
+func SSLRootCert() string { return sslRootCert }
+
+func SetHost(newHost string)               { host = newHost }
+func SetPort(newPort int)                  { port = newPort }
+func SetUsername(newUsername string)       { username = newUsername }
+func SetPassword(newPassword string)       { password = newPassword }
+func SetDatabase(newDatabase string)       { database = newDatabase }
+func SetOptions(newOptions string)         { options = newOptions }
+func SetSSLMode(newSSLMode string)         { sslMode = newSSLMode }
+func SetSSLRootCert(newSSLRootCert string) { sslRootCert = newSSLRootCert }

--- a/database/database.go
+++ b/database/database.go
@@ -1,7 +1,12 @@
 package database
 
-import "github.com/alfreddobradi/go-bb-man/parser"
+import (
+	"github.com/alfreddobradi/go-bb-man/parser"
+	"github.com/google/uuid"
+)
 
 type DB interface {
 	SaveReplay(record parser.Record) error
+	GetReplayList() ([]parser.Record, error)
+	GetReplay(id uuid.UUID) (parser.Record, error)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,66 @@
+version: '3'
+
+services:
+  roach1:
+    image: cockroachdb/cockroach:v22.1.10
+    networks:
+      - roachnet
+    ports:
+      - 26257:26257
+      - 8080:8080
+    volumes:
+      - roach1-data:/cockroach/cockroach-data
+    command: "start --insecure --join=roach1,roach2,roach3"
+    healthcheck:
+      test: [ "curl", "http://localhost:8080/health" ]
+      interval: 1m30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
+  roach2:
+    image: cockroachdb/cockroach:v22.1.10
+    networks:
+      - roachnet
+    volumes:
+      - roach2-data:/cockroach/cockroach-data
+    command: "start --insecure --join=roach1,roach2,roach3"
+    healthcheck:
+      test: [ "curl", "http://localhost:8080/health" ]
+      interval: 1m30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
+  roach3:
+    image: cockroachdb/cockroach:v22.1.10
+    networks:
+      - roachnet
+    volumes:
+      - roach3-data:/cockroach/cockroach-data
+    command: "start --insecure --join=roach1,roach2,roach3"
+    healthcheck:
+      test: [ "curl", "http://localhost:8080/health" ]
+      interval: 1m30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
+  gobblerd:
+    image: gobblerd:latest
+    ports:
+      - "80:8080"
+    networks:
+      - roachnet
+    environment:
+      - GOBBLER_DB_USERNAME=root
+      - GOBBLER_DB_HOST=roach1
+      - GOBBLER_DB_PORT=26257
+      - GOBBLER_DB_DATABASE=gobb_dev
+      - GOBBLER_DB_SSL_MODE=disable
+
+networks:
+  roachnet:
+
+
+volumes:
+  roach1-data:
+  roach2-data:
+  roach3-data:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/alfreddobradi/go-bb-man
 go 1.14
 
 require (
+	github.com/alfreddobradi/goconf v1.0.0
 	github.com/cockroachdb/cockroach-go/v2 v2.2.16
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/alfreddobradi/goconf v1.0.0 h1:ZgFNWhkR31gY6e/bjrEHzL8ODfglAWUG5gdwGbKo78g=
+github.com/alfreddobradi/goconf v1.0.0/go.mod h1:bQOHecdl/uAaVBQrUg0b0o3/FYhcKUBA9YnRIDntwTs=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go/v2 v2.2.16 h1:t9dmZuC9J2W8IDQDSIGXmP+fBuEJSsrGXxWQz4cYqBY=
@@ -202,8 +204,9 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/postgres v1.3.5/go.mod h1:EGCWefLFQSVFrHGy4J8EtiHCWX5Q8t0yz2Jt9aKkGzU=
 gorm.io/gorm v1.23.4/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=
 gorm.io/gorm v1.23.5/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=

--- a/helper/http.go
+++ b/helper/http.go
@@ -1,0 +1,12 @@
+package helper
+
+import "net/http"
+
+func E(w http.ResponseWriter, status int) {
+	http.Error(w, http.StatusText(status), status)
+}
+
+func CorsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Max-Age", "86400")
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -66,14 +66,14 @@ type rawPlayerData struct {
 	Armor               int    `xml:"PlayerData>Av"`
 	Strength            int    `xml:"PlayerData>St"`
 	Skills              string `xml:"PlayerData>ListSkills"`
-	XP                  int
-	InflictedTackles    int `xml:"Statistics>InflictedTackles"`
-	SustainedTackles    int `xml:"Statistics>SustainedTackles"`
-	InflictedInjuries   int `xml:"Statistics>InflictedInjuries"`
-	SustainedInjuries   int `xml:"Statistics>SustainedInjuries"`
-	InflictedCasualties int `xml:"Statistics>InflictedCasualties"`
-	SustainedCasualties int `xml:"Statistics>SustainedCasualties"`
-	MVP                 int `xml:"Statistics>MVP"`
+	XP                  int    `xml:"Xp"`
+	InflictedTackles    int    `xml:"Statistics>InflictedTackles"`
+	SustainedTackles    int    `xml:"Statistics>SustainedTackles"`
+	InflictedInjuries   int    `xml:"Statistics>InflictedInjuries"`
+	SustainedInjuries   int    `xml:"Statistics>SustainedInjuries"`
+	InflictedCasualties int    `xml:"Statistics>InflictedCasualties"`
+	SustainedCasualties int    `xml:"Statistics>SustainedCasualties"`
+	MVP                 int    `xml:"Statistics>MVP"`
 	Casualty1           int
 	Casualty2           int
 }


### PR DESCRIPTION
This PR adds quite a few changes that were necessary to expose the service for collaboration.

* Added a configuration layer that reads values from the environment variables or a config file
* Added a dockerized CRDB cluster and default configuration that will connect to it
* Added a detailed README.md file to help starting work with the application
* Added API endpoints to query existing replays (`/api/replays` and `/api/replays/{id}`) - the response is returned as JSON objects