### PR TITLE
feat: Include competition and league in records

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Then we create the database and the single table we'll have for now:
 > USE gobb_dev;
 > CREATE TABLE replays (
       id uuid NOT NULL,
+      competition jsonb NOT NULL,
       home_team jsonb NOT NULL,
       away_team jsonb NOT NULL
   );

--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -97,6 +97,9 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		logger.WithFields(log.Fields{
+			"address": s.Addr,
+		}).Info("Starting HTTP listener")
 		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			logger.WithError(err).Error("Error in HTTP listener")
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -12,7 +12,13 @@ type Replay struct {
 }
 
 type ReplayStep struct {
+	GameInfos              GameInfos
 	RulesEventGameFinished RulesEventGameFinished
+}
+
+type GameInfos struct {
+	League      string `xml:"RowLeague>Name"`
+	Competition string `xml:"RowCompetition>Name"`
 }
 
 type RulesEventGameFinished struct {

--- a/parser/record.go
+++ b/parser/record.go
@@ -7,9 +7,15 @@ import (
 )
 
 type Record struct {
-	ID   uuid.UUID
-	Home TeamStats
-	Away TeamStats
+	ID          uuid.UUID
+	Competition Competition
+	Home        TeamStats
+	Away        TeamStats
+}
+
+type Competition struct {
+	League      string
+	Competition string
 }
 
 type TeamStats struct {
@@ -48,10 +54,17 @@ type TeamStats struct {
 }
 
 func NewRecordFromReplay(replay Replay) Record {
-	finished := replay.ReplaySteps[len(replay.ReplaySteps)-1].RulesEventGameFinished
-	stats := finished.Statistics
-	homeTeam := finished.Coaches[0].TeamResult
-	awayTeam := finished.Coaches[1].TeamResult
+	gameInfos := replay.ReplaySteps[0].GameInfos
+
+	competition := Competition{
+		League:      gameInfos.League,
+		Competition: gameInfos.Competition,
+	}
+
+	gameFinished := replay.ReplaySteps[len(replay.ReplaySteps)-1].RulesEventGameFinished
+	stats := gameFinished.Statistics
+	homeTeam := gameFinished.Coaches[0].TeamResult
+	awayTeam := gameFinished.Coaches[1].TeamResult
 
 	home := TeamStats{
 		Name:                       stats.TeamHomeName,
@@ -131,11 +144,12 @@ func NewRecordFromReplay(replay Replay) Record {
 		}
 	}
 
-	id := uuid.NewSHA1(uuid.NameSpaceDNS, []byte(fmt.Sprintf("%s-%s:%s-%s", home.Name, home.CoachName, away.Name, away.CoachName)))
+	id := uuid.NewSHA1(uuid.NameSpaceDNS, []byte(fmt.Sprintf("%s:%s:%s-%s:%s-%s", competition.League, competition.Competition, home.Name, home.CoachName, away.Name, away.CoachName)))
 
 	return Record{
-		ID:   id,
-		Home: home,
-		Away: away,
+		ID:          id,
+		Competition: competition,
+		Home:        home,
+		Away:        away,
 	}
 }


### PR DESCRIPTION
This PR includes the competition information (comp. and league name) in the record stored in the DB.

It also contains a minor fix in case there's no replay to return with the requested ID at `/api/replays/{id}`.