### PR TITLE
chore: simplify local environment setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+database_entrypoint
+docker-compose.yml
+_sandbox/

--- a/README.md
+++ b/README.md
@@ -2,50 +2,7 @@
 
 *All commands - unless specified otherwise - should be ran from the project root*
 
-### Initializing the local CockroachDB cluster
-
-**This only needs to be done if the cluster hasn't been initialized yet or the volumes have been recreated**
-
-Start the Cockroach nodes:
-
-```
-$ docker compose up roach1 roach2 roach3
-```
-
-Once the nodes are running they'll warn about being unable to communicate with other nodes in the cluster.
-To fix this, we'll have to initialize the cluster on the first node. In a new tab/window run the following:
-
-```
-$ docker compose exec roach1 ./cockroach init --insecure
-```
-
-Once this finishes, the nodes should find each other and they each report their own info in the original docker compose output.
-
-Now the nodes can communicate with each other we should create the schema:
-
-First we connect to the server running on the roach1 node
-
-```
-$ docker compose exec roach1 ./cockroach sql --insecure
-```
-
-Then we create the database and the single table we'll have for now:
-
-```
-> CREATE DATABASE gobb_dev;
-> USE gobb_dev;
-> CREATE TABLE replays (
-      id uuid NOT NULL,
-      home_team jsonb NOT NULL,
-      away_team jsonb NOT NULL
-  );
-```
-
-When this is done, quit the cockroach client (Ctrl+D) and shut the cluster down by pressing Ctrl+C in the docker compose tab/window
-
 ### Starting the daemon
-
-Provided the initialization worked, this is quite simple:
 
 Build the image:
 

--- a/database_entrypoint/a.sql
+++ b/database_entrypoint/a.sql
@@ -1,0 +1,8 @@
+CREATE DATABASE gobb_dev;
+USE gobb_dev;
+
+CREATE TABLE replays (
+	id uuid NOT NULL,
+	home_team jsonb NOT NULL,
+	away_team jsonb NOT NULL
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,33 +10,8 @@ services:
       - 8080:8080
     volumes:
       - roach1-data:/cockroach/cockroach-data
-    command: "start --insecure --join=roach1,roach2,roach3"
-    healthcheck:
-      test: [ "curl", "http://localhost:8080/health" ]
-      interval: 1m30s
-      timeout: 30s
-      retries: 5
-      start_period: 30s
-  roach2:
-    image: cockroachdb/cockroach:v22.1.10
-    networks:
-      - roachnet
-    volumes:
-      - roach2-data:/cockroach/cockroach-data
-    command: "start --insecure --join=roach1,roach2,roach3"
-    healthcheck:
-      test: [ "curl", "http://localhost:8080/health" ]
-      interval: 1m30s
-      timeout: 30s
-      retries: 5
-      start_period: 30s
-  roach3:
-    image: cockroachdb/cockroach:v22.1.10
-    networks:
-      - roachnet
-    volumes:
-      - roach3-data:/cockroach/cockroach-data
-    command: "start --insecure --join=roach1,roach2,roach3"
+      - ./database_entrypoint/:/docker-entrypoint-initdb.d/
+    command: "start-single-node --insecure"
     healthcheck:
       test: [ "curl", "http://localhost:8080/health" ]
       interval: 1m30s
@@ -62,5 +37,3 @@ networks:
 
 volumes:
   roach1-data:
-  roach2-data:
-  roach3-data:


### PR DESCRIPTION
Set up the cockroachdb cluster in single node cluster mode so we only need one instance of it. This also adds the database initialization as a docker entrypoint script in `database_entrypoint/a.sql`. This removes the need to manually connect and initialize the database schema when brining this up locally. Files in this directory are mounted to the roach1 db container's docker-entrypoint directory and are executed automatically in alphabetical order.

Added a .dockerignore file.